### PR TITLE
Make Social menu new window optional

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -9,11 +9,6 @@ jQuery(function($) {
     $('body').fitVids();
 });
 
-//Open social links in a new tab
-jQuery(function($) {
-     $( '.social-navigation li a' ).attr( 'target','_blank' );
-});
-
 //Toggle sidebar
 jQuery(function($) {
 	$('.sidebar-toggle').click(function() {


### PR DESCRIPTION
WordPress has built in option for opening menu links in new tab so we shouldn't force them on user. Closes: https://github.com/Codeinwp/oblique/issues/98